### PR TITLE
hotfix: fixed issue that led to panic when calling api to generate a image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,6 @@ WORKDIR /app
 COPY ./assets /app/assets
 COPY ./api /app/api
 COPY --from=buildenv /build/tawnyfm /app/tawnyfm
+COPY --from=buildenv /etc/ssl /etc/ssl
 
 ENTRYPOINT ["/app/tawnyfm"]

--- a/internal/pkg/server/hmac_proxyAction.go
+++ b/internal/pkg/server/hmac_proxyAction.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/dozro/tawny/internal/pkg/apiError"
@@ -49,6 +50,12 @@ func performProxyAction(request *HmacProxyRequest, c *gin.Context) {
 		{
 			log.Debug("proxy action: user.NowPlayingEmbed")
 			ct, err := client.GetUserCurrentTrack(request.ApiParameters.Username, proxyConfig.LastFMAPIKey)
+			if ct == nil || err != nil {
+				e := fmt.Errorf("Unexpected or error", err)
+				log.Error(e)
+				c.AbortWithError(http.StatusInternalServerError, e)
+				return
+			}
 			img, err := embed.EmbedNowPlaying(ct.Track[0].Name, ct.Track[0].Artist.Name, ct.Track[0].Album, ct.Track[0].Image)
 			if handleError(err, c) {
 				return

--- a/internal/pkg/server/hmac_types.go
+++ b/internal/pkg/server/hmac_types.go
@@ -30,12 +30,19 @@ func HmacSignedRequestToBase64(request HmacSignedRequest) HmacBase64SignedReques
 func Base64ToHmacSignedRequest(b64 HmacBase64SignedRequest) (HmacSignedRequest, error) {
 	log.Debugf("decoding base64 signed request: %s", b64)
 
-	// Base64 decode the JSON request payload
-	decoded, err := base64.StdEncoding.DecodeString(string(b64.Request))
-	if err != nil {
-		e := fmt.Errorf("failed to decode base64 request: %w", err)
-		log.Error(e)
-		return HmacSignedRequest{}, e
+	var decoded []byte
+	if json.Valid(b64.Request) {
+		log.Debugf("data is already decoded, will skip base64 decoding")
+		decoded = b64.Request
+	} else {
+		// Base64 decode the JSON request payload
+		var err error
+		decoded, err = base64.StdEncoding.DecodeString(string(b64.Request))
+		if err != nil {
+			e := fmt.Errorf("failed to decode base64 request: %w", err)
+			log.Error(e)
+			return HmacSignedRequest{}, e
+		}
 	}
 
 	if !json.Valid(decoded) {

--- a/internal/pkg/server/user.go
+++ b/internal/pkg/server/user.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/dozro/tawny/internal/pkg/client"
@@ -94,6 +95,12 @@ func getUserCurrentTrackEmbed(c *gin.Context) {
 	}
 	img, err := embed.EmbedNowPlaying(ct.Track[0].Name, ct.Track[0].Artist.Name, ct.Track[0].Album, ct.Track[0].Image)
 	if handleError(err, c) {
+		return
+	}
+	if img == nil {
+		e := fmt.Errorf("image not found")
+		log.Error("no valid image data found")
+		c.AbortWithError(http.StatusInternalServerError, e)
 		return
 	}
 	c.Data(http.StatusOK, "image/png", img.Bytes())


### PR DESCRIPTION
This pull request introduces improvements to error handling and data validation in the server logic, as well as a minor update to the Dockerfile to ensure SSL certificates are available in the runtime environment. The main changes focus on making the API more robust against invalid input and unexpected states, particularly in user track embedding and request decoding.

**Error Handling and Data Validation Improvements**

* Added explicit error handling for missing or erroneous user track data in `performProxyAction`, aborting the request with a server error when necessary (`internal/pkg/server/hmac_proxyAction.go`).
* Improved validation in `Base64ToHmacSignedRequest` to skip base64 decoding if the request is already valid JSON, preventing unnecessary decoding and errors (`internal/pkg/server/hmac_types.go`).
* Added error handling for missing image data in `getUserCurrentTrackEmbed`, aborting with a server error if the image is not found (`internal/pkg/server/user.go`).

**Dependency and Environment Updates**

* Updated the Dockerfile to copy SSL certificates from the build environment, ensuring secure connections in the deployed application (`Dockerfile`).

**Code Quality**

* Imported the `fmt` package in relevant files to support improved error formatting and logging (`internal/pkg/server/hmac_proxyAction.go`, `internal/pkg/server/user.go`). [[1]](diffhunk://#diff-ad4b3da5e6974806b2cc09507eb439100e17a5399636c8178bb93554e268ebcbR4) [[2]](diffhunk://#diff-77feb2880fcc3e3b4baf93d7915861bab16341f7e8db786736533c5aefd1a4e0R4)