### PR TITLE
enh: updated placement of text

### DIFF
--- a/internal/pkg/embed/NowPlaying.go
+++ b/internal/pkg/embed/NowPlaying.go
@@ -32,6 +32,11 @@ func EmbedNowPlaying(track_title string, track_artist string, track_album string
 		return nil, fmt.Errorf("failed to load background image: %w", err)
 	}
 
+	//artistSymbole, err := gg.LoadImage("assets/images/singer.png")
+	//if err != nil {
+	//	return nil, fmt.Errorf("failed to load artist symbole image: %w", err)
+	//}
+
 	imgWidth := bgImage.Bounds().Dx()
 	imgHeight := bgImage.Bounds().Dy()
 
@@ -53,15 +58,18 @@ func EmbedNowPlaying(track_title string, track_artist string, track_album string
 	textY := float64(imgHeight/2 - 60)
 
 	dc.SetColor(color.White)
-	drawTextWithGlow(dc, track_title, textX, textY-100, 300, 50, color.White)
+	drawTextWithGlow(dc, truncateString(track_title, 40), textX-50, textY-100, 450, 50, color.White)
 
 	dc.LoadFontFace(pathToFont, 28)
 	dc.SetColor(color.RGBA{220, 220, 220, 255})
-	dc.DrawStringWrapped(track_artist, textX, textY+60, 0, 0, textWidth, 1.3, gg.AlignLeft)
+	dc.DrawStringWrapped(truncateString(track_album, 35), textX, textY+60, 0, 0, textWidth, 1.3, gg.AlignLeft)
 
 	dc.LoadFontFace(pathToFont, 24)
 	dc.SetColor(color.RGBA{180, 180, 180, 255})
-	dc.DrawStringWrapped(track_album, textX, textY+110, 0, 0, textWidth, 1.3, gg.AlignLeft)
+	dc.DrawStringWrapped(truncateString(track_artist, 40), textX, textY+110, 0, 0, textWidth, 1.3, gg.AlignLeft)
+
+	//artistSymbole = resizeImage(artistSymbole, 30, 30)
+	//dc.DrawImage(artistSymbole, int(textX-30), int(textY+105))
 
 	dc.LoadFontFace(pathToFont, 18)
 	dc.SetColor(color.RGBA{220, 161, 161, 233})

--- a/internal/pkg/embed/helper.go
+++ b/internal/pkg/embed/helper.go
@@ -1,0 +1,14 @@
+package embed
+
+func truncateString(str string, num int) string {
+	truncated := ""
+	count := 0
+	for _, char := range str {
+		truncated += string(char)
+		count++
+		if count >= num {
+			break
+		}
+	}
+	return truncated
+}


### PR DESCRIPTION
This pull request introduces improvements to the rendering of the "Now Playing" embed, focusing on better handling of long text fields and code organization. The changes ensure that track titles, artists, and album names are truncated for visual consistency, and refactor truncation logic into a helper function.

**Text truncation and rendering improvements:**

* Truncate `track_title`, `track_album`, and `track_artist` strings to fixed lengths before rendering, preventing overflow and maintaining layout consistency in the embed. (`internal/pkg/embed/NowPlaying.go`)

**Code organization and maintainability:**

* Added a new helper function `truncateString` in `internal/pkg/embed/helper.go` to centralize and simplify string truncation logic. (`internal/pkg/embed/helper.go`)

**Commented-out code for future enhancements:**

* Added (but commented out) code to load and render an artist symbol image, suggesting planned future UI enhancements. (`internal/pkg/embed/NowPlaying.go`) [[1]](diffhunk://#diff-00ca1c0f1299065692d68736d3e854b14bd6fa8d175c9efc4691e61f97a54eb1R35-R39) [[2]](diffhunk://#diff-00ca1c0f1299065692d68736d3e854b14bd6fa8d175c9efc4691e61f97a54eb1L56-R72)