### PR TITLE
enh: updated embed text

### DIFF
--- a/internal/pkg/embed/NowPlaying.go
+++ b/internal/pkg/embed/NowPlaying.go
@@ -13,7 +13,7 @@ import (
 
 const pathToFont = "assets/fonts/RubikMarker/RubikMarkerHatch-Regular.ttf"
 
-func EmbedNowPlaying(track_title string, track_artist string, track_album string, track_album_cover string) (*bytes.Buffer, error) {
+func EmbedNowPlaying(track_title string, track_artist string, track_album string, track_album_cover string, username string, now bool) (*bytes.Buffer, error) {
 	// Albumcover herunterladen
 	albumCoverResp, err := doHttpGetRequest(track_album_cover)
 	if err != nil {
@@ -74,6 +74,11 @@ func EmbedNowPlaying(track_title string, track_artist string, track_album string
 	dc.LoadFontFace(pathToFont, 18)
 	dc.SetColor(color.RGBA{220, 161, 161, 233})
 	dc.DrawStringWrapped("Generated with Tawny based on last.fm data", 10, 390, 0, 0, textWidth+100, 1.3, gg.AlignLeft)
+	if now {
+		dc.DrawStringWrapped(fmt.Sprintf("%s is currently listening", username), 75, 15, 0, 0, textWidth+100, 1.3, gg.AlignLeft)
+	} else {
+		dc.DrawStringWrapped(fmt.Sprintf("%s was recently listening", username), 75, 15, 0, 0, textWidth+100, 1.3, gg.AlignLeft)
+	}
 
 	outputImage := dc.Image()
 	buf := new(bytes.Buffer)

--- a/internal/pkg/server/hmac_proxyAction.go
+++ b/internal/pkg/server/hmac_proxyAction.go
@@ -56,7 +56,7 @@ func performProxyAction(request *HmacProxyRequest, c *gin.Context) {
 				c.AbortWithError(http.StatusInternalServerError, e)
 				return
 			}
-			img, err := embed.EmbedNowPlaying(ct.Track[0].Name, ct.Track[0].Artist.Name, ct.Track[0].Album, ct.Track[0].Image)
+			img, err := embed.EmbedNowPlaying(ct.Track[0].Name, ct.Track[0].Artist.Name, ct.Track[0].Album, ct.Track[0].Image, request.ApiParameters.Username, ct.Track[0].NowPlaying)
 			if handleError(err, c) {
 				return
 			}

--- a/internal/pkg/server/user.go
+++ b/internal/pkg/server/user.go
@@ -93,7 +93,7 @@ func getUserCurrentTrackEmbed(c *gin.Context) {
 	if handleError(err, c) {
 		return
 	}
-	img, err := embed.EmbedNowPlaying(ct.Track[0].Name, ct.Track[0].Artist.Name, ct.Track[0].Album, ct.Track[0].Image)
+	img, err := embed.EmbedNowPlaying(ct.Track[0].Name, ct.Track[0].Artist.Name, ct.Track[0].Album, ct.Track[0].Image, username, ct.Track[0].NowPlaying)
 	if handleError(err, c) {
 		return
 	}


### PR DESCRIPTION
This pull request updates the `EmbedNowPlaying` functionality to display the user's listening status (currently or recently listening) on the generated image. The changes introduce two new parameters—`username` and `now`—to the `EmbedNowPlaying` function and update all relevant call sites to pass these values. The image now includes a personalized status message based on whether the track is currently being played.

Enhancements to user status display:

* Added `username` and `now` parameters to the `EmbedNowPlaying` function in `internal/pkg/embed/NowPlaying.go`, allowing personalized status messages on the image.
* Updated the image generation logic to display either "is currently listening" or "was recently listening" based on the `now` parameter.

Updates to function calls:

* Modified calls to `EmbedNowPlaying` in `internal/pkg/server/hmac_proxyAction.go` and `internal/pkg/server/user.go` to pass the new `username` and `now` arguments, ensuring correct status display. [[1]](diffhunk://#diff-ad4b3da5e6974806b2cc09507eb439100e17a5399636c8178bb93554e268ebcbL59-R59) [[2]](diffhunk://#diff-77feb2880fcc3e3b4baf93d7915861bab16341f7e8db786736533c5aefd1a4e0L96-R96)