### PR TITLE
Fix(apispec): Set isBase64 to optional (hotfix/apispec-error-base64)

### DIFF
--- a/api/openapi/paths/hmac_execute.yaml
+++ b/api/openapi/paths/hmac_execute.yaml
@@ -11,6 +11,7 @@ post:
         type: boolean
     - name: isBase64
       deprecated: true
+      required: false
       description: if the request is base64 encoded
       in: query
       schema:
@@ -47,7 +48,7 @@ get:
   parameters:
     - name: isBase64
       description: if the request is base64 encoded
-      required: true
+      required: false
       deprecated: true
       in: query
       schema:

--- a/api/openapi/paths/hmac_sign.yaml
+++ b/api/openapi/paths/hmac_sign.yaml
@@ -37,6 +37,7 @@ post:
         type: boolean
       in: query
       deprecated: true
+      required: false
       description: Deprecated alias for `is_base64`.
       name: isBase64
   requestBody:


### PR DESCRIPTION
Fixes an issue where the isBase64 parameter was incorrectly marked as required in the OpenAPI specification. The parameter is now correctly set to optional in both hmac_sign.yaml and hmac_execute.yaml.

*Copilot generated change summary*:

This pull request updates the OpenAPI specifications for the `hmac_execute` and `hmac_sign` endpoints to make the deprecated `isBase64` query parameter optional instead of required. This change improves backward compatibility for clients that no longer use this parameter.

OpenAPI specification updates:

* Changed the `isBase64` query parameter from required to optional in both the `post` and `get` operations of `api/openapi/paths/hmac_execute.yaml`. [[1]](diffhunk://#diff-861d9a0c88aac0fd734c288b45a3562e95f0411db6a0d4ede0c8dd00ac5a2b2eR14) [[2]](diffhunk://#diff-861d9a0c88aac0fd734c288b45a3562e95f0411db6a0d4ede0c8dd00ac5a2b2eL50-R51)
* Changed the `isBase64` query parameter from required to optional in the `post` operation of `api/openapi/paths/hmac_sign.yaml`.