### PR TITLE
feat: Automatic semver from git tag (feat/automativ-semver-in-prog)

### DIFF
--- a/.github/workflows/ghcr-pub.yml
+++ b/.github/workflows/ghcr-pub.yml
@@ -17,7 +17,9 @@ on:
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
   pull_request:
-    branches: [ "main" ]
+    branches:
+      - "main"
+      - "devel"
 
 env:
   # Use docker.io for Docker Hub if empty
@@ -40,15 +42,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@c2d88d3ecc89a9ef08eebf45d9637801dcee7eb5
-      - name: Extract version number
+      - name: Set version variables
         id: vars
         run: |
-          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
-            echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-          else
-            echo "VERSION=" >> $GITHUB_OUTPUT
-          fi
-
+          echo "GIT_DESCRIBE_VERSION=$(git describe --tags --always --long --match 'v[0-9]*.[0-9]*.[0-9]*')" >> $GITHUB_ENV
+          echo "GIT_LATEST_HASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "BRANCH_NAME=${GITHUB_REF_NAME}" >> $GITHUB_ENV
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
@@ -91,9 +90,15 @@ jobs:
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
-          #platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7,linux/386,linux/ppc64le,linux/riscv64,linux/s390x
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            ${{env.IMAGE_NAME}}:${{ env.GIT_LATEST_HASH }}
+            ${{env.IMAGE_NAME}}:latest-dev
+            ${{env.IMAGE_NAME}}:${{ env.GIT_DESCRIBE_VERSION }}
+          build-args: |
+            IMAGE_VERSION=${{ env.GIT_DESCRIBE_VERSION }}
+            GIT_REVISION=${{ env.GIT_LATEST_HASH }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -106,7 +111,11 @@ jobs:
         if: ${{ github.event_name != 'pull_request' }}
         env:
           # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
-          TAGS: ${{ steps.meta.outputs.tags }}
+          TAGS: |
+            ${{ steps.meta.outputs.tags }}
+            ${{env.IMAGE_NAME}}:${{ env.GIT_LATEST_HASH }}
+            ${{env.IMAGE_NAME}}:latest-dev
+            ${{env.IMAGE_NAME}}:${{ env.GIT_DESCRIBE_VERSION }}
           DIGEST: ${{ steps.build-and-push.outputs.digest }}
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,9 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o tawnyfm ./cmd/fm-proxy/main.go
 
 FROM scratch
 
+ARG IMAGE_VERSION=unspecified
+ARG GIT_REVISION=unspecified
+
 LABEL org.opencontainers.image.source="https://github.com/dozro/tawny"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 
@@ -23,6 +26,8 @@ EXPOSE 8080
 ENV TAWNY_RELEASE_MODE=true
 ENV TAWNY_DEVELOP_MODE=false
 ENV TAWNY_RUNNING_IN_DOCKER=true
+ENV TAWNY_INTERNAL_VERSION=$IMAGE_VERSION
+ENV TAWNY_INTERNAL_REVISION=$GIT_REVISION
 
 WORKDIR /app
 COPY ./assets /app/assets

--- a/cmd/fm-proxy/main.go
+++ b/cmd/fm-proxy/main.go
@@ -10,6 +10,9 @@ import (
 func main() {
 	log.Info("starting fm-proxy")
 	config := server_config.SetupServerConfig()
+	if config.ExtendedServerConfig.RunningInDocker {
+		log.Infof("This server is running on tawny version %s with revision %s", config.ExtendedServerConfig.TawnyVersion, config.ExtendedServerConfig.TawnyRevision)
+	}
 	if config.DebugMode {
 		log.SetLevel(log.DebugLevel)
 	} else if config.ReleaseMode {

--- a/internal/pkg/server_config/ServerConfig.go
+++ b/internal/pkg/server_config/ServerConfig.go
@@ -31,6 +31,8 @@ type ExtendedServerConfig struct {
 	RunningInDocker            bool   `json:"running_in_docker"`
 	LogOutputFormat            string `json:"log_output_format"`
 	DisableEmbeddedMusicBrainz bool   `json:"disable_embedded_music_brainz"`
+	TawnyVersion               string `json:"tawny_version"`
+	TawnyRevision              string `json:"tawny_revision"`
 }
 
 func SetupServerConfig() *ServerConfig {
@@ -53,6 +55,8 @@ func SetupServerConfig() *ServerConfig {
 	disableMusicBrainzEndpoints := ch.GetBooleanOption(sc.ConfigEntry{Key: "DISABLE_MUSICBRAINZ_ENDPOINTS", Description: "Disable MusicBrainz Endpoints", DefaultBool: false})
 	disableEmbeddedMusicBrainz := ch.GetBooleanOption(sc.ConfigEntry{Key: "DISABLE_MUSICBRAINZ_EMBEDDING", Description: "Disable the enrichment with MusicBrainz data", DefaultBool: false})
 	disableSwaggerUI := ch.GetBooleanOption(sc.ConfigEntry{Key: "DISABLE_SWAGGER_UI", Description: "Disable Swagger UI", DefaultBool: false})
+	tawnyVers := ch.GetStringOption(sc.ConfigEntry{Key: "INTERNAL_VERSION", Description: "[internal] TAWNY Version (don't set this yourself)", DefaultString: "unspecified"})
+	tawnyRev := ch.GetStringOption(sc.ConfigEntry{Key: "INTERNAL_REVISION", Description: "[internal] TAWNY Revision (don't set this yourself)", DefaultString: "unspecified"})
 	ch.ParseFlags()
 	return &ServerConfig{
 		ApiPort:      *apiport,
@@ -74,6 +78,8 @@ func SetupServerConfig() *ServerConfig {
 			RunningInDocker:            *runningInDocker,
 			LogOutputFormat:            *logOutputFormat,
 			DisableEmbeddedMusicBrainz: *disableEmbeddedMusicBrainz,
+			TawnyRevision:              *tawnyRev,
+			TawnyVersion:               *tawnyVers,
 		},
 	}
 }

--- a/internal/pkg/server_config/ServerConfig.go
+++ b/internal/pkg/server_config/ServerConfig.go
@@ -78,8 +78,8 @@ func SetupServerConfig() *ServerConfig {
 			RunningInDocker:            *runningInDocker,
 			LogOutputFormat:            *logOutputFormat,
 			DisableEmbeddedMusicBrainz: *disableEmbeddedMusicBrainz,
-			TawnyRevision:              *tawnyRev,
 			TawnyVersion:               *tawnyVers,
+			TawnyRevision:              *tawnyRev,
 		},
 	}
 }

--- a/scripts/build-docker-image.sh
+++ b/scripts/build-docker-image.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 GIT_DESCRIBE_VERSION="$(git describe --tags --always --long --match 'v[0-9]*.[0-9]*.[0-9]*')"
 GIT_LATEST_HASH="$(git rev-parse --short HEAD)"

--- a/scripts/build-docker-image.sh
+++ b/scripts/build-docker-image.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+GIT_DESCRIBE_VERSION="$(git describe --tags --always --long --match 'v[0-9]*.[0-9]*.[0-9]*')"
+GIT_LATEST_HASH="$(git rev-parse --short HEAD)"
+
+echo "Building version: $GIT_DESCRIBE_VERSION"
+echo "Commit Hash: $GIT_LATEST_HASH"
+
+docker build \
+  --build-arg IMAGE_VERSION="$GIT_DESCRIBE_VERSION" \
+  --build-arg GIT_REVISION="$GIT_LATEST_HASH" \
+  -t tawnyfm:"$GIT_LATEST_HASH" \
+  -t tawnyfm:latest-dev \
+  -t tawnyfm:"$GIT_DESCRIBE_VERSION" \
+  .

--- a/scripts/versioning-from-git-tag.sh
+++ b/scripts/versioning-from-git-tag.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 export GIT_LATEST_TAG="$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*')"
 export GIT_DESCRIBE_VERSION="$(git describe --tags --always --long --match 'v[0-9]*.[0-9]*.[0-9]*')"

--- a/scripts/versioning-from-git-tag.sh
+++ b/scripts/versioning-from-git-tag.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export GIT_LATEST_TAG="$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*')"
+export GIT_DESCRIBE_VERSION="$(git describe --tags --always --long --match 'v[0-9]*.[0-9]*.[0-9]*')"
+export GIT_LATEST_HASH="$(git rev-parse --short HEAD)"


### PR DESCRIPTION
Adds scripts for versioning from git tags and building docker images.

This commit introduces:
- `scripts/versioning-from-git-tag.sh`: Script to export `GIT_LATEST_TAG`, `GIT_DESCRIBE_VERSION`, and `GIT_LATEST_HASH`.
- `scripts/build-docker-image.sh`: Script to build Docker image with version and revision build arguments.
- Updates to `Dockerfile` to accept `IMAGE_VERSION` and `GIT_REVISION` build arguments.
- Updates to `ServerConfig` to include `TawnyVersion` and `TawnyRevision`.
- Updates to main.go to output the version and revision if running in docker.

*Copilot generated Overview*:

This pull request introduces automatic versioning and revision tracking for the Tawny FM Proxy Docker image and application. The changes ensure that each build embeds its Git version and revision, making deployments more traceable and improving debugging and support. The most important changes are grouped below.

**Versioning and Revision Injection:**

* Added `IMAGE_VERSION` and `GIT_REVISION` build arguments to the `Dockerfile`, which are passed as environment variables (`TAWNY_INTERNAL_VERSION`, `TAWNY_INTERNAL_REVISION`) into the container. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R18-R20) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R29-R30)
* Updated the `ExtendedServerConfig` struct and its setup to include new fields for version and revision, which are populated from environment variables. [[1]](diffhunk://#diff-1a2f00f116e7541268b8e7c22291dfaef0dbddfa6573d78f8fe8016c13dfbf40R34-R35) [[2]](diffhunk://#diff-1a2f00f116e7541268b8e7c22291dfaef0dbddfa6573d78f8fe8016c13dfbf40R58-R59) [[3]](diffhunk://#diff-1a2f00f116e7541268b8e7c22291dfaef0dbddfa6573d78f8fe8016c13dfbf40R81-R82)

**Build and Versioning Scripts:**

* Added `scripts/build-docker-image.sh` to automate Docker image builds with Git version and revision tags, and apply multiple image tags for traceability.
* Added `scripts/versioning-from-git-tag.sh` to export Git versioning information for use in other scripts or CI workflows.

**Logging and Diagnostics:**

* Updated `cmd/fm-proxy/main.go` to log the Tawny version and revision at startup when running in Docker, aiding diagnostics and support.