### PR TITLE
feat: Add server info endpoint (feat/server-information-endpoint)

### DIFF
--- a/api/openapi/openapi.yaml
+++ b/api/openapi/openapi.yaml
@@ -43,6 +43,8 @@ paths:
     $ref: ./paths/musicbrainz_lookup_artist_by_mbid_mbid_.yaml
   /musicbrainz/lookup/recording/by_mbid/{mbid}:
     $ref: ./paths/musicbrainz_lookup_recording_by_mbid_mbid_.yaml
+  /meta/serverinfo:
+    $ref: ./paths/meta_serverinfo.yaml
 components:
   schemas:
     $ref: ./schemas/_index.yaml

--- a/api/openapi/paths/meta_serverinfo.yaml
+++ b/api/openapi/paths/meta_serverinfo.yaml
@@ -1,0 +1,18 @@
+get:
+  security: [ ]
+  summary: Execute a signed HMAC proxy request
+  tags:
+    - meta
+  responses:
+    '200':
+      description: successful request
+      content:
+        application/json:
+          schema:
+            $ref: ../schemas/ServerInfo.yaml
+        application/yaml:
+          schema:
+            $ref: ../schemas/ServerInfo.yaml
+        application/xml:
+          schema:
+            $ref: ../schemas/ServerInfo.yaml

--- a/api/openapi/schemas/ServerDisabledEndpoints.yaml
+++ b/api/openapi/schemas/ServerDisabledEndpoints.yaml
@@ -1,0 +1,30 @@
+type: object
+description: Which Api Endpoints are currently disabled by server configuration
+xml:
+  name: "DisabledEndpoints"
+properties:
+  disable_hmac_signing_endpoint:
+    type: boolean
+    default: false
+    xml:
+      name: "DisableHMACSigningEndpoint"
+  disable_image_embedded_endpoint:
+    type: boolean
+    default: false
+    xml:
+      name: "DisableImageEmbeddedEndpoints"
+  enable_only_hmac_endpoints:
+    type: boolean
+    default: false
+    xml:
+      name: "EnableOnlyHMACEndpoints"
+  disable_music_brainz_endpoints:
+    type: boolean
+    default: false
+    xml:
+      name: "DisableMusicBrainzEndpoints"
+  disable_swagger_ui:
+    type: boolean
+    default: false
+    xml:
+      name: "DisableSwaggerUI"

--- a/api/openapi/schemas/ServerInfo.yaml
+++ b/api/openapi/schemas/ServerInfo.yaml
@@ -1,0 +1,35 @@
+type: object
+description: Information about server
+xml:
+  name: "serverInfoRespType"
+properties:
+  tawny_version:
+    type: string
+    nullable: true
+    example: "v0.0.3-90-g86bbc97"
+    default: "unspecified"
+    xml:
+      name: "TawnyVersion"
+  tawny_revision:
+    type: string
+    nullable: true
+    example: "g86bbc97"
+    default: "unspecified"
+    xml:
+      name: "TawnyRevision"
+  source_repository:
+    type: string
+    nullable: true
+    example: "https://github.com/example/example"
+    xml:
+      name: "SourceRepository"
+  gin_version:
+    type: string
+    nullable: true
+    example: "v1.0.0"
+    xml:
+      name: "GinVersion"
+  operator:
+    $ref: ./ServerOperator.yaml
+  disabled_endpoints:
+    $ref: ./ServerDisabledEndpoints.yaml

--- a/api/openapi/schemas/ServerOperator.yaml
+++ b/api/openapi/schemas/ServerOperator.yaml
@@ -1,0 +1,33 @@
+type: object
+description: Information about server Operator
+xml:
+  name: "Operator"
+properties:
+  name:
+    type: string
+    description: The name of the server Operator
+    example: "ACME Corporation"
+    default: "unspecified"
+    xml:
+      name: "Name"
+  contact:
+    type: string
+    description: Contact of the server operator
+    example: 'abuse@example.org'
+    default: "unspecified"
+    xml:
+      name: "Contact"
+  imprint_url:
+    type: string
+    description: link to the imprint of the server operator
+    example: 'https://example.org/imprint'
+    default: "unspecified"
+    xml:
+      name: "ImprintURL"
+  privacy_policy_url:
+    type: string
+    description: link to the privacy policy of the server operator
+    example: 'https://example.org/privacy_policy'
+    default: "unspecified"
+    xml:
+      name: "PrivacyPolicyURL"

--- a/api/openapi/schemas/_index.yaml
+++ b/api/openapi/schemas/_index.yaml
@@ -74,3 +74,9 @@ LastFMURL:
   $ref: ./LastFMURL.yaml
 HMACSignature:
   $ref: ./HMACSignature.yaml
+ServerInfo:
+  $ref: ./ServerInfo.yaml
+ServerOperator:
+  $ref: ./ServerOperator.yaml
+ServerDisabledEndpoints:
+  $ref: ./ServerDisabledEndpoints.yaml

--- a/api/openapi/tags/_index.yaml
+++ b/api/openapi/tags/_index.yaml
@@ -2,3 +2,5 @@ user:
   $ref: ./user.yaml
 hmac:
   $ref: ./hmac.yaml
+meta:
+  $ref: ./meta.yaml

--- a/api/openapi/tags/meta.yaml
+++ b/api/openapi/tags/meta.yaml
@@ -1,0 +1,2 @@
+name: meta
+description: Operations related to meta operations of the tawny server

--- a/internal/pkg/api_commons/httpclient.go
+++ b/internal/pkg/api_commons/httpclient.go
@@ -1,8 +1,11 @@
 package api_commons
 
-import "net/http"
+import (
+	"fmt"
+	"net/http"
+)
 
-const userAgent = "Tawny/0.0.3 (Linux; +https://github.com/dozro/tawny; +abuse@itsrye.dev)"
+var userAgent = "Tawny/0.0.3 (Linux; +https://github.com/dozro/tawny; +abuse@itsrye.dev)"
 
 var httpClient = &http.Client{}
 
@@ -15,6 +18,27 @@ func doHttpGetRequestJSONWithAuth(url, auth string) (*http.Response, error) {
 	req.Header.Set("Authorization", auth)
 	req.Header.Set("Accept", "application/json")
 	return httpClient.Do(req)
+}
+
+type UserAgentSetupArgs struct {
+	Version            string
+	Repository         string
+	SourceAbuseContact string
+	OperatorContact    string
+	OperatorName       string
+	OperatorImprint    string
+}
+
+func SetUpUserAgent(args UserAgentSetupArgs) {
+	userAgent = fmt.Sprintf(
+		"Tawny/%s (+%s; abuse: %s; operator: %s; contact: %s; imprint: %s)",
+		args.Version,
+		args.Repository,
+		args.SourceAbuseContact,
+		args.OperatorName,
+		args.OperatorContact,
+		args.OperatorImprint,
+	)
 }
 
 func doHttpGetRequest(url string) (*http.Response, error) {

--- a/internal/pkg/server/init.go
+++ b/internal/pkg/server/init.go
@@ -11,16 +11,18 @@ var middlewareHMACEndpointRegex *regexp.Regexp
 var middlewareEmbedEndpointRegex *regexp.Regexp
 var middlewareHMACSignEndpointRegex *regexp.Regexp
 var middlewareMusicBrainzEndpointRegex *regexp.Regexp
+var middlewareServerInfoEndpointRegex *regexp.Regexp
 var supportedImageTypes *regexp.Regexp
 
 func init() {
 	hmacProxyUserInfoRegex = regexp.MustCompile(`^[/_]?user/?$`)
 	hmacProxyUserNowPlayingRegex = regexp.MustCompile(`^[/_]?user[/_]tracks[/_]current/?$`)
-	hmacProxyUserNowPlayingEmbed = regexp.MustCompile(`^^[/_]?user[/_]tracks[/_]current[/_]embed/?$`)
+	hmacProxyUserNowPlayingEmbed = regexp.MustCompile(`^[/_]?user[/_]tracks[/_]current[/_]embed/?$`)
 	hmacProxyUserRecentlyPlayedRegex = regexp.MustCompile(`^[/_]?user[/_]tracks[/_]recent/?$`)
 	middlewareHMACEndpointRegex = regexp.MustCompile(`^/?hmac/`)
 	middlewareEmbedEndpointRegex = regexp.MustCompile(`/embed$`)
 	middlewareHMACSignEndpointRegex = regexp.MustCompile(`^/?hmac/sign`)
 	middlewareMusicBrainzEndpointRegex = regexp.MustCompile(`^/?musicbrainz/`)
+	middlewareServerInfoEndpointRegex = regexp.MustCompile(`^/?meta/serverinfo`)
 	supportedImageTypes = regexp.MustCompile(`image/(png|tiff|jpeg)`)
 }

--- a/internal/pkg/server/serverInfo.go
+++ b/internal/pkg/server/serverInfo.go
@@ -1,0 +1,45 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/dozro/tawny/internal/pkg/server_config"
+	"github.com/gin-gonic/gin"
+)
+
+type serverInfoRespType struct {
+	TawnyVersion      string                                `json:"tawny_version" xml:"TawnyVersion"`
+	TawnyRevision     string                                `json:"tawny_revision" xml:"TawnyRevision"`
+	SourceRepository  string                                `json:"source_repository" yaml:"source_repository" xml:"SourceRepository"`
+	GinVersion        string                                `json:"gin_version" yaml:"gin_version" xml:"GinVersion"`
+	Operator          ServerInfoOp                          `json:"operator" yaml:"operator" xml:"Operator"`
+	DisabledEndpoints server_config.ServerDisabledEndpoints `json:"disabled_endpoints" xml:"DisabledEndpoints"`
+}
+
+type ServerInfoOp struct {
+	Name             string `json:"name" xml:"Name"`
+	Contact          string `json:"contact" xml:"Contact"`
+	ImprintURL       string `json:"imprint_url" xml:"ImprintURL"`
+	PrivacyPolicyURL string `json:"privacy_policy_url" xml:"PrivacyPolicyURL"`
+}
+
+func serverInfo(c *gin.Context) {
+	resp := serverInfoRespType{}
+	resp.TawnyVersion = proxyConfig.ExtendedServerConfig.TawnyVersion
+	resp.TawnyRevision = proxyConfig.ExtendedServerConfig.TawnyRevision
+	if proxyConfig.ExtendedServerConfig.DisableGinVersionPublished {
+		resp.GinVersion = "hidden"
+	} else {
+		resp.GinVersion = gin.Version
+	}
+	resp.SourceRepository = proxyConfig.ExtendedServerConfig.SourceCodeURL
+	resp.Operator = ServerInfoOp{
+		Name:             proxyConfig.ServerOperator.OperatorName,
+		Contact:          proxyConfig.ServerOperator.OperatorContact,
+		ImprintURL:       proxyConfig.ServerOperator.ImprintURL,
+		PrivacyPolicyURL: proxyConfig.ServerOperator.PrivacyPolicyURL,
+	}
+
+	resp.DisabledEndpoints = proxyConfig.DisabledEndpoints
+	render(c, http.StatusOK, resp)
+}

--- a/internal/pkg/server/swagger.go
+++ b/internal/pkg/server/swagger.go
@@ -9,7 +9,7 @@ import (
 )
 
 func serveSwagger(router *gin.Engine) {
-	if proxyConfig.DevelopMode {
+	if !proxyConfig.ExtendedServerConfig.RunningInDocker {
 		router.StaticFS("/openapi/", http.Dir("./api/openapi"))
 		router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler, ginSwagger.URL("/openapi/openapi.yaml")))
 	} else {

--- a/internal/pkg/server_config/ServerConfig.go
+++ b/internal/pkg/server_config/ServerConfig.go
@@ -17,6 +17,7 @@ type ServerConfig struct {
 	DevelopMode          bool                    `json:"develop_mode"`
 	DisabledEndpoints    ServerDisabledEndpoints `json:"disabled_endpoints"`
 	ExtendedServerConfig ExtendedServerConfig    `json:"extended_server_config"`
+	ServerOperator       ServerOperatorInfo      `json:"server_operator"`
 }
 
 type ServerDisabledEndpoints struct {
@@ -27,12 +28,23 @@ type ServerDisabledEndpoints struct {
 	DisableSwaggerUI              bool `json:"disable_swagger_ui"`
 }
 
+type ServerOperatorInfo struct {
+	OperatorName     string `json:"operator_name"`
+	OperatorContact  string `json:"operator_contact"`
+	PrivacyPolicyURL string `json:"privacy_policy_url"`
+	ImprintURL       string `json:"imprint_url"`
+}
+
 type ExtendedServerConfig struct {
 	RunningInDocker            bool   `json:"running_in_docker"`
 	LogOutputFormat            string `json:"log_output_format"`
 	DisableEmbeddedMusicBrainz bool   `json:"disable_embedded_music_brainz"`
+	DisableGinVersionPublished bool   `json:"disable_gin_version_published"`
+	HideSensitiveInformation   bool   `json:"hide_sensitive_information"`
 	TawnyVersion               string `json:"tawny_version"`
 	TawnyRevision              string `json:"tawny_revision"`
+	SourceCodeURL              string `json:"source_code_url"`
+	SourceAbuseContact         string `json:"source_abuse_contact"`
 }
 
 func SetupServerConfig() *ServerConfig {
@@ -57,6 +69,14 @@ func SetupServerConfig() *ServerConfig {
 	disableSwaggerUI := ch.GetBooleanOption(sc.ConfigEntry{Key: "DISABLE_SWAGGER_UI", Description: "Disable Swagger UI", DefaultBool: false})
 	tawnyVers := ch.GetStringOption(sc.ConfigEntry{Key: "INTERNAL_VERSION", Description: "[internal] TAWNY Version (don't set this yourself)", DefaultString: "unspecified"})
 	tawnyRev := ch.GetStringOption(sc.ConfigEntry{Key: "INTERNAL_REVISION", Description: "[internal] TAWNY Revision (don't set this yourself)", DefaultString: "unspecified"})
+	disableGinVersionPublication := ch.GetBooleanOption(sc.ConfigEntry{Key: "GIN_VERSION_EXPOSE", Description: "do you want to expose the gin version?", DefaultBool: false})
+	dontexposesensitiveinformation := ch.GetBooleanOption(sc.ConfigEntry{Key: "DONT_EXPOSE_SENSITIVE_INFORMATION", Description: "Do you want to hide potentially sensitive information", DefaultBool: false})
+	operator := ch.GetStringOption(sc.ConfigEntry{Key: "OPERATOR", Description: "Operator name, if you wish to publish it", DefaultString: "unspecified"})
+	operatorContact := ch.GetStringOption(sc.ConfigEntry{Key: "OPERATOR_CONTACT", Description: "Operator contact (email, link)", DefaultString: "unspecified"})
+	operatorPrivacyPolicy := ch.GetStringOption(sc.ConfigEntry{Key: "OPERATOR_PRIVACY_POLICY", Description: "A link to your privacy policy (may be required in some jurisdictions)", DefaultString: "unspecified"})
+	operatorImprint := ch.GetStringOption(sc.ConfigEntry{Key: "OPERATOR_IMPRINT", Description: "A link to your imprint (may be required in some jurisdictions, especially Germany)", DefaultString: "unspecified"})
+	sourceCodeURL := ch.GetStringOption(sc.ConfigEntry{Key: "SOURCE_CODE_URL", Description: "Source Code URL, please change if you forked or modified the source", DefaultString: "https://github.com/dozro/tawny"})
+	sourceAbuseContact := ch.GetStringOption(sc.ConfigEntry{Key: "SOURCE_ABUSE_CONTACT", Description: "Abuse contact, please change if you forked or modified the source", DefaultString: "abuse@itsrye.dev"})
 	ch.ParseFlags()
 	return &ServerConfig{
 		ApiPort:      *apiport,
@@ -80,6 +100,16 @@ func SetupServerConfig() *ServerConfig {
 			DisableEmbeddedMusicBrainz: *disableEmbeddedMusicBrainz,
 			TawnyVersion:               *tawnyVers,
 			TawnyRevision:              *tawnyRev,
+			DisableGinVersionPublished: *disableGinVersionPublication,
+			HideSensitiveInformation:   *dontexposesensitiveinformation,
+			SourceCodeURL:              *sourceCodeURL,
+			SourceAbuseContact:         *sourceAbuseContact,
+		},
+		ServerOperator: ServerOperatorInfo{
+			OperatorName:     *operator,
+			OperatorContact:  *operatorContact,
+			PrivacyPolicyURL: *operatorPrivacyPolicy,
+			ImprintURL:       *operatorImprint,
 		},
 	}
 }


### PR DESCRIPTION
This commit introduces a new endpoint `/meta/serverinfo` that exposes server information like:

- Tawny version and revision
- Source code repository URL
- Gin version
- Operator information (name, contact, imprint, privacy policy)
- Disabled endpoints

Additionally:
- Adds configuration options for operator information.
- Adds configuration options to hide gin version and sensitive info.
- Updates user agent string to include operator information.
- swagger documentation updated.